### PR TITLE
fix(hobot-display): [RDK-431] Adjust display timing strategy

### DIFF
--- a/debian/usr/bin/process_hobot_output.py
+++ b/debian/usr/bin/process_hobot_output.py
@@ -1,0 +1,115 @@
+import sys
+import re
+
+def parse_and_sort():
+    sections = []
+    current_section = []
+    current_header = None
+
+    # print("################ in parse_and_sort ################")
+    # 需要排序的区块标识（严格匹配）
+    sort_headers = {
+        '#EST Timing',
+        '#STD(DMT) Timing',
+        '#CEA Timing'
+    }
+
+    # 处理输入并分块
+    for line in sys.stdin:
+        # line = line.rstrip('\n')
+        line = line.rstrip()
+        if line.startswith('#'):
+            if current_header is not None:
+                sections.append((current_header, current_section))
+            current_header = line
+            current_section = []
+        else:
+            current_section.append(line)
+    
+    if current_header is not None:
+        sections.append((current_header, current_section))
+
+    # print("################ in parse_and_sort ################")
+    # 处理每个区块
+    processed = []
+    for header, lines in sections:
+        # print(f"fuhua - check {header}")
+        # print(f"fuhua - check {lines}")
+        processed.append(header)
+        if header not in sort_headers:
+            processed.extend(lines)
+            continue
+        
+        entries = []
+        other_lines = []
+        has_modeline = False
+        for line in lines:
+            # print(f"fuhua - check {line}")
+            # 捕获 Modeline/ModeLine 行（兼容大小写和空格）
+            if re.match(r'^\s*(Modeline|ModeLine)\s+"', line, re.I):
+                has_modeline = True
+                # 提取模式参数
+                mode_match = re.search(r'"([^"]+)"', line)
+                if not mode_match:
+                    other_lines.append(line)
+                    continue
+                mode = mode_match.group(1)
+                
+                # 解析宽、高、刷新率（精确到小数点）
+                try:
+                    width_part, rest = mode.split('x', 1)
+                    width = int(width_part)
+                    height_part, refresh_part = rest.split('_', 1)
+                    height = int(height_part)
+                    refresh = float(refresh_part.split('.', 1)[0])  # 取整数部分
+                except (ValueError, IndexError) as e:
+                    # print(f"DEBUG: 解析失败 [{line}]", file=sys.stderr)
+                    other_lines.append(line)
+                    continue
+                
+                # 生成三级降序排序键（宽度→高度→刷新率）
+                entries.append((-width, -height, -refresh, line))
+            else:
+                other_lines.append(line)
+        
+        # # 打印排序前的 entries
+        # print("\n[DEBUG] === 排序前 entries ===", file=sys.stderr)
+        # for entry in entries:
+        #     print(f"  {entry[0]} -> {entry[1]}", file=sys.stderr)
+        
+        # 执行排序
+        entries.sort()
+        
+        # # 打印排序后的 entries
+        # print("\n[DEBUG] === 排序后 entries ===", file=sys.stderr)
+        # for entry in entries:
+        #     print(f"  {entry[0]} -> {entry[1]}", file=sys.stderr)
+        
+        # 合并结果：保留注释，插入排序后的时序
+        processed.extend(other_lines)
+        for entry in entries:
+            processed.append(entry[3])
+
+    # 如果没有 Modeline，添加默认时序
+    if not has_modeline:
+        processed.append("    # no edid get, we set default modeline")
+        default_modelines = [
+            'Modeline "1920x1080_60.00" 148.5 1920 2008 2052 2200 1080 1084 1089 1125 +HSync +VSync',
+            # 'Modeline "1920x1080_60.00" 74.25 1920 2008 2052 2200 1080 1082 1087 1125 +HSync +VSync',
+            'Modeline "1920x1080_30.00" 74.25 1920 2008 2052 2200 1080 1084 1089 1125 +HSync +VSync',
+            'Modeline "1280x720_60.00" 74.25 1280 1390 1430 1650 720 725 730 750 +HSync +VSync',
+            # 'Modeline "1280x720_50.00" 74.25 1280 1720 1760 1980 720 725 730 750 +HSync +VSync'
+            'Modeline "1280x720_30.00" 74.25 1280 3040 3080 3300 720 725 730 750 +HSync +VSync'
+
+        ]
+        processed.extend(default_modelines)
+
+    # print("################ end parse_and_sort ################")
+    # 输出最终结果
+    processed = [f"\t{line}" for line in processed]  # 所有行统一缩进
+    print('\n'.join(processed))
+
+if __name__ == '__main__':
+    # print("######## start process_hobot_output.py ###########")
+    parse_and_sort()
+    # print("######## end process_hobot_output.py ###########")

--- a/debian/usr/bin/run_hobot_display_service.sh
+++ b/debian/usr/bin/run_hobot_display_service.sh
@@ -210,56 +210,111 @@ function cfg_update {
 
 # vim: filetype=sh
 
+filter_unsupported_modes() {
+    local mode_line="$1"
+
+    # 提取分辨率和刷新率
+    resolution=$(echo "$mode_line" | awk '{print $2}' | tr -d '"')
+    # echo "resolution = $resolution" >&2
+    refresh_rate=$(echo "$resolution" | awk -F'_' '{print $2}' | awk -F'.' '{print $1}')
+    # echo "refresh_rate = $refresh_rate" >&2
+
+    # 提取分辨率和刷新率
+    resolution=$(echo "$mode_line" | awk '{print $2}' | tr -d '"')
+    # echo "resolution = $resolution" >&2
+
+    # 新增刷新率提取整数和小数
+    refresh_info=$(echo "$resolution" | awk -F'_' '{print $2}')
+    refresh_rate=$(echo "$refresh_info" | awk -F'.' '{print $1}')
+    refresh_rate_decimal=$(echo "$refresh_info" | awk -F'.' '{print $2}')
+
+    # 调试用
+    # echo "DEBUG: resolution=$resolution, refresh_info=$refresh_info, refresh_rate=$refresh_rate, refresh_rate_decimal=$refresh_rate_decimal" >&2
+
+    width=$(echo "$resolution" | awk -F'x' '{print $1}')
+    # echo "width = $width" >&2
+    height=$(echo "$resolution" | awk -F'x|_' '{print $2}')
+    # echo "height = $height" >&2
+
+    # 验证提取的参数是否为数字
+    if ! [[ "$width" =~ ^[0-9]+$ && "$height" =~ ^[0-9]+$ ]]; then
+      #   echo "ERROR: Invalid resolution: $resolution" >&2
+        echo "$mode_line"  # 过滤非Modeline的打印，此部分一般为带 # 的注释。
+        return 1
+    fi
+
+    # 计算分辨率乘积
+    local max_pixel_area=$((1920 * 1080))  # 基准分辨率乘积
+    local current_pixel_area=$((width * height))
+
+    # 应用过滤规则：分辨率乘积 > 1920x1080 或 刷新率 > 60 或者 刷新率不为整数的
+    if [[ "$current_pixel_area" -gt "$max_pixel_area" || "$refresh_rate" -gt 60 ]]; then
+      #   echo "DEBUG: Filtering high resolution: $resolution (width=$width, height=$height)" >&2
+      #   echo "#$mode_line"   # 调试打印
+      sed -E 's/^[[:blank:]]*/        #/' <<< "$mode_line" # 屏蔽超高分辨率和高刷模式
+    elif [[ "$refresh_rate" -gt 60 ]]; then
+      #   屏蔽超高分辨率和高刷模式
+      #   echo "#$mode_line"  # 调试打印
+      sed -E 's/^[[:blank:]]*/        #/' <<< "$mode_line"
+    # 检查刷新率是否为整数
+   #  elif [[ -n "$refresh_rate_decimal" && "$refresh_rate_decimal" != "0" && "$refresh_rate_decimal" != "00" && "$refresh_rate_decimal" != "000" ]]; then
+   #      # 刷新率不是整数，屏蔽此模式
+   #      sed -E 's/^[[:blank:]]*/        #/' <<< "$mode_line"
+   #      return 0
+    else
+      #   echo "DEBUG: Allowing mode: $resolution" >&2
+        echo "$mode_line"   # 保留支持的模式
+    fi
+}
+
+
 function auto_edid() {
-   modes=$(get_edid_raw_data | edid-decode-linux-tv -X | grep "Modeline" | sed 's/^[ \t]*//g' | sed 's/.*/"&"/')
-   if [ -z "$modes" ]; then
-      #default timing genrate using https://tomverbeure.github.io/video_timings_calculator
-      modes=("	Modeline \"1920x1080_30\" 74.25 1920 2008 2052 2200 1080 1084 1089 1125 +HSync +VSync
-      Modeline \"1920x1080_60\" 148.5 1920 2008 2052 2200 1080 1084 1089 1125 +HSync +VSync
-      Modeline \"1280x720_60\" 74.25 1280 1390 1430 1650 720 725 730 750 +HSync +VSync
-      Modeline \"1280x720_30\" 74.25 1280 3040 3080 3300 720 725 730 750 +HSync +VSync
-      Modeline \"1024x768_60\" 65 1024 1048 1184 1344 768 771 777 806 -HSync -VSync
-      Modeline \"1024x768_30\" 25.932 1024 1032 1064 1104 768 769 777 783 +HSync -VSync
-      Modeline \"800x600_60.32\" 40 800 840 968 1056 600 601 605 628 +HSync +VSync
-      Modeline \"640x480_75\" 31.5 640 656 720 840 480 481 484 500 -HSync -VSync"
+    modes=$(get_edid_raw_data | edid-decode-linux-tv -X | grep "Modeline" | sed 's/^[ \t]*//g' | sed 's/.*/"&"/')
+    if [ -z "$modes" ]; then
+        #default timing genrate using https://tomverbeure.github.io/video_timings_calculator
+        modes=("    Modeline \"1920x1080_30\" 74.25 1920 2008 2052 2200 1080 1084 1089 1125 +HSync +VSync
+        Modeline \"1920x1080_60\" 148.5 1920 2008 2052 2200 1080 1084 1089 1125 +HSync +VSync
+        Modeline \"1280x720_60\" 74.25 1280 1390 1430 1650 720 725 730 750 +HSync +VSync
+        Modeline \"1280x720_30\" 74.25 1280 3040 3080 3300 720 725 730 750 +HSync +VSync
+        Modeline \"1024x768_60\" 65 1024 1048 1184 1344 768 771 777 806 -HSync -VSync
+        Modeline \"1024x768_30\" 25.932 1024 1032 1064 1104 768 769 777 783 +HSync -VSync
+        Modeline \"800x600_60.32\" 40 800 840 968 1056 600 601 605 628 +HSync +VSync
+        Modeline \"640x480_75\" 31.5 640 656 720 840 480 481 484 500 -HSync -VSync"
+        )
+    fi
+    modes_array=()
+    filtered_output=()
 
-      )
-   fi
-   modes_array=()
-   filtered_output=()
-
-   template_monitor='
+    template_monitor='
 Section "Monitor"
     Identifier "default"
     #replace_1
 EndSection
 '
 
-   while IFS= read -r line; do
-      modes_array+=("$line")
-   done <<<"$modes"
+    sorted_hobot_output=$(hobot_parse_std_timing | python3 /usr/bin/process_hobot_output.py)
+    # echo "$sorted_hobot_output" >&2
+    while IFS= read -r line; do
+        modes_array+=("$line")
+    done <<< "$sorted_hobot_output"
 
-   while IFS= read -r line; do
-      modes_array+=("$line")
-   done < <(hobot_parse_std_timing)
+    for item in "${modes_array[@]}"; do
+        if [[ ! "$item" =~ "Interlace" ]]; then
+            filtered_output+=("$(filter_unsupported_modes "$item")")
+            # filtered_output+=("$item")
+        fi
+    done
 
-   for item in "${modes_array[@]}"; do
-      if [[ ! "$item" =~ "Interlace" ]]; then
-         filtered_output+=("$item")
-      fi
-   done
+    result=""
+    for item in "${filtered_output[@]}"; do
+        result="$result$(echo "$item" | sed 's/^"\(.*\)"$/\1/')"$'\n'
+    done
 
-   result=""
-   for item in "${filtered_output[@]}"; do
-      #echo $(echo "$item" | sed 's/^"\(.*\)"$/\1/')
-      result="$result$(echo "$item" | sed 's/^"\(.*\)"$/\1/')"$'\n'
-   done
+    monitor_result="${template_monitor//#replace_1/$result}"
 
-   monitor_result="${template_monitor//#replace_1/$result}"
+    echo "$monitor_result"
 
-   echo "$monitor_result"
-
-   template_screen='
+    template_screen='
 Section "Screen"
     Identifier "MyScreen"
     Device "MyVideoCard" 
@@ -270,33 +325,46 @@ Section "Screen"
     EndSubSection
 EndSection'
 
-   second_elements=()
+    second_elements=()
 
-   for sentence in "${filtered_output[@]}"; do
-      if [[ "$sentence" != "#"* ]]; then
-         second_element=$(echo "$sentence" | awk '{print $2}' | tr -d '"') 
+    for sentence in "${filtered_output[@]}"; do
+        # 跳过以 # 开头的行（已注释的 Modeline 或普通注释）
+        if [[ ! "$sentence" =~ [[:space:]]*# ]]; then
+            # 使用正则表达式直接提取分辨率参数（格式："WxH_FPS"）
+            if [[ "$sentence" =~ \ \"([0-9]+x[0-9]+_[0-9]+(\.[0-9]+)?)\" ]]; then
+                second_element="${BASH_REMATCH[1]}"
 
-         # 解析宽、高、刷新率
-         width=$(echo "$second_element" | cut -d'x' -f1)
-         height_refresh_rate=$(echo "$second_element" | cut -d'x' -f2)
+                # 解析宽、高、刷新率（整数部分）
+                width=$(echo "$second_element" | cut -d'x' -f1)
+                height_refresh=$(echo "$second_element" | cut -d'x' -f2)
+                height=$(echo "$height_refresh" | cut -d'_' -f1)
+                refresh_rate=$(echo "$height_refresh" | cut -d'_' -f2 | cut -d'.' -f1)
 
-         height=$(echo "$height_refresh_rate" | awk -F'_' '{print $1}')       
-         refresh_rate=$(echo "$height_refresh_rate" | awk -F'_' '{print $2}')
-
-         # 过滤条件
-         if ((height <= 1080 && width <= 1920 )); then
-            if [ -n "$second_element" ]; then
-               second_elements+=("\"$second_element\"")
+                # 验证是否为数字
+                if [[ "$width" =~ ^[0-9]+$ && "$height" =~ ^[0-9]+$ ]]; then
+                    # 应用过滤条件
+                    local max_pixel_area=$((1920 * 1080))  # 基准分辨率乘积
+                    local current_pixel_area=$((width * height))
+                  #   if (( width <= 1920 && height <= 1080 )); then
+                  if (( "$current_pixel_area" <= "$max_pixel_area" )); then
+                        # 去重：避免重复添加相同的模式
+                        if [[ ! " ${second_elements[@]} " =~ " \"$second_element\" " ]]; then
+                            second_elements+=("\"$second_element\"")
+                        fi
+                    fi
+                else
+                    echo "ERROR: Invalid resolution format: $second_element" >&2
+                fi
+            else
+                echo "WARN: Skipping non-Modeline line: $sentence" >&2
             fi
-         fi
-      fi
-   done
+        fi
+    done
 
-   IFS=$'\n' sorted_second_elements=($(sort -t'x' -k1,1nr -k2,2nr <<<"${second_elements[*]}"))
-   unset IFS
+   modes_string="$(printf '%s ' "${second_elements[@]}")"
+   modes_string="${modes_string% }"  # 去除末尾空格
 
-   modes_string="$(printf ' %s' "${sorted_second_elements[@]}")"
-
+   # 替换模板占位符
    result="${template_screen//#replace_2/$modes_string}"
 
    fbdev_temp='
@@ -306,10 +374,12 @@ Section "Device"
         Option "fbdev" "/dev/fb0"
 EndSection
 '
-   echo "$monitor_result" >/usr/share/X11/xorg.conf.d/01-monitor.conf
-   echo "$fbdev_temp" >>/usr/share/X11/xorg.conf.d/01-monitor.conf
-   echo "$result" >>/usr/share/X11/xorg.conf.d/01-monitor.conf
+       echo "$monitor_result" >/usr/share/X11/xorg.conf.d/01-monitor.conf
+       echo "$fbdev_temp" >>/usr/share/X11/xorg.conf.d/01-monitor.conf
+       echo "$result" >>/usr/share/X11/xorg.conf.d/01-monitor.conf
 }
+
+auto_edid
 timing_params=""
 function config_parse() {
    config_file="/boot/config.txt"

--- a/hobot_display_services/hobot_parse_std_timing.c
+++ b/hobot_display_services/hobot_parse_std_timing.c
@@ -16,6 +16,25 @@ struct edid_cta_mode
     int refresh, hor_freq_hz, pixclk_khz;
 };
 
+struct detailed_timing {
+    int pixel_clock;    // 像素时钟(kHz)
+    int h_active;
+    int h_blank;
+    int v_active;
+    int v_blank;
+    int h_sync_off;     // H同步开始位置（相对h_active）
+    int h_sync_pulse;   // H同步脉冲宽度
+    int v_sync_off;     // V同步开始位置（相对v_active）
+    int v_sync_pulse;   // V同步脉冲宽度
+    int h_size_mm;      // 水平尺寸(mm)
+    int v_size_mm;      // 垂直尺寸(mm)
+    int h_border;       // 水平边框像素
+    int v_border;       // 垂直边框行数
+    int interlaced;     // 是否隔行
+    int h_sync_polarity; // H同步极性(1=正,0=负)
+    int v_sync_polarity; // V同步极性(1=正,0=负)
+};
+
 static struct edid_cta_mode edid_cta_modes1[] = {
     /* VIC 1 */
     {"Modeline \"640x480_60.00\" 25.175 640 656 752 800 480 490 492 525 +HSync +VSync", "640x480@60Hz 4:3", 60, 31469, 25175},
@@ -412,6 +431,83 @@ int findElementWithField(const char *arr[], int arrSize, const char *field)
     return -1;
 }
 
+// 详细时序解析函数
+static int parse_detailed_timing(const unsigned char *desc, struct detailed_timing *dt)
+{
+    // 检查前两个字节是否为0（非时序描述符）
+    if (desc[0] == 0 && desc[1] == 0)
+        return 0;
+
+    memset(dt, 0, sizeof(*dt));
+
+    // 解析像素时钟（单位：10kHz）
+    dt->pixel_clock = (desc[1] << 8 | desc[0]) * 10; // 转换为kHz
+
+    // 水平参数
+    dt->h_active  = ((desc[4] & 0xf0) << 4) | desc[2];
+    dt->h_blank   = ((desc[4] & 0x0f) << 8) | desc[3];
+
+    // 垂直参数
+    dt->v_active  = ((desc[7] & 0xf0) << 4) | desc[5];
+    dt->v_blank   = ((desc[7] & 0x0f) << 8) | desc[6];
+
+    // 同步参数
+    dt->h_sync_off   = ((desc[11] & 0xc0) << 2) | desc[8];
+    dt->h_sync_pulse = ((desc[11] & 0x30) << 4) | desc[9];
+    dt->v_sync_off   = ((desc[11] & 0x0c) << 2) | ((desc[10] & 0xf0) >> 4);
+    dt->v_sync_pulse = ((desc[11] & 0x03) << 4) | (desc[10] & 0x0f);
+
+    // 图像尺寸
+    dt->h_size_mm = desc[14];
+    dt->v_size_mm = desc[15];
+
+    // 边框
+    dt->h_border = desc[16];
+    dt->v_border = desc[17];
+
+    // 标志位解析
+    dt->interlaced = (desc[17] & 0x80) >> 7;
+    dt->h_sync_polarity = (desc[17] & 0x02) >> 1;
+    dt->v_sync_polarity = (desc[17] & 0x04) >> 2;
+
+    return 1;
+}
+
+// 生成Modeline字符串
+static void generate_modeline(const struct detailed_timing *dt, char *buf, size_t len)
+{
+    int h_total = dt->h_active + dt->h_blank;
+    int v_total = dt->v_active + dt->v_blank;
+
+    double pixclk_mhz = dt->pixel_clock / 1000.0;
+
+    // 计算各阶段位置
+    int h_begin = dt->h_active + dt->h_sync_off;
+    int h_end = h_begin + dt->h_sync_pulse;
+
+    int v_begin = dt->v_active + dt->v_sync_off;
+    int v_end = v_begin + dt->v_sync_pulse;
+
+    // 生成同步极性字符串
+    char h_sync = dt->h_sync_polarity ? '+' : '-';
+    char v_sync = dt->v_sync_polarity ? '+' : '-';
+
+    snprintf(buf, len,
+        "Modeline \"%dx%d_%.2f\" %.2f %d %d %d %d %d %d %d %d %cHSync %cVSync",
+        dt->h_active, dt->v_active,
+        (dt->pixel_clock * 1000.0) / (h_total * v_total), // 刷新率
+        pixclk_mhz,
+        dt->h_active,
+        dt->h_active + dt->h_sync_off,
+        dt->h_active + dt->h_sync_off + dt->h_sync_pulse,
+        h_total,
+        dt->v_active,
+        dt->v_active + dt->v_sync_off,
+        dt->v_active + dt->v_sync_off + dt->v_sync_pulse,
+        v_total,
+        h_sync, v_sync);
+}
+
 static int get_est_timing(unsigned char *block)
 {
     int idx = 0;
@@ -563,6 +659,21 @@ static int get_std_timing(unsigned char *block)
     int i;
     char *mode = NULL;
     int found = 0;
+
+    // 检查 block 是否全为 0x00
+    int all_zero = 1;
+    for (i = 0; i < 2; i++) {
+        if (block[i] != 0x00) {
+            all_zero = 0;
+            break;
+        }
+    }
+
+    if (all_zero) {
+        // 如果 block 全为 0x00，直接返回未找到
+        return 0;
+    }
+
     for (i = 0; i < DMT_SIZE; i++)
     {
         unsigned int std_2byte_code = block[0] << 8 | block[1];
@@ -730,11 +841,27 @@ int main()
 
     // block 1: est timing
     printf("#Automatically generated, please do not edit\r\n");
+
+    /*生成 Detailed Timing 字段*/
+    printf("#Detailed Timing Descriptors\n");
+    const unsigned char *desc = data.edid_data + 0x36;
+    for (int i = 0; i < 4; i++, desc += 18) {
+        struct detailed_timing dt;
+        if (parse_detailed_timing(desc, &dt)) {
+            char modeline[256];
+            generate_modeline(&dt, modeline, sizeof(modeline));
+            printf("%s\n", modeline);
+        }
+    }
+
+    /*生成 EST Timing 字段*/
     printf("#EST Timing\r\n");
     block = data.edid_data + 0x23;
     ret = get_est_timing(block);
     if (!ret)
         perr("get_est_timing fail!\r\n");
+
+    /*生成 TD(DMT) Timing 和扩展快中的 Timing 字段*/
     // block 2:std timing
     printf("#STD(DMT) Timing\r\n");
     block = data.edid_data + 0x26;


### PR DESCRIPTION
Summary:
- Filter high refresh rate timings to avoid unsupported modes
- Support non-standard display timings as much as possible
- Use conventional timing as fallback when EDID is unavailable